### PR TITLE
broccoliモジュールの削除処理追加

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var plumber = require("gulp-plumber");//コンパイルエラーが起きても 
 var rename = require("gulp-rename");//ファイル名の置き換えを行う
 var twig = require("gulp-twig");//Twigテンプレートエンジン
 var browserify = require("gulp-browserify");//NodeJSのコードをブラウザ向けコードに変換
+var rimraf = require('rimraf');// The UNIX command `rm -rf` for node.
 var packageJson = require(__dirname+'/package.json');
 var _tasks = [
 	'.html',
@@ -84,6 +85,9 @@ gulp.task(".html.twig", function() {
 
 // broccoli-client (frontend) を処理
 gulp.task("broccoli-client", function() {
+	gulp.task('clean', function (cb) {
+	  rimraf('./dist/libs/broccoli-*', cb);
+	});
 	gulp.src(["node_modules/broccoli-module-bootstrap3/dist/**/*"])
   	.pipe(gulp.dest("./dist/libs/broccoli-module-bootstrap3/client/dist/"))
 	;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.html",
   "scripts": {
     "preinstall": "git submodule update -i -r",
+    "postinstall": "npm rebuild node-sass",
     "start": "nw",
     "up": "node ./node_modules/baobab-fw/lib/cmd/server.js",
     "test": "gulp; mocha --ui tdd ./tests/",
@@ -32,6 +33,7 @@
     "phpjs": "^1.3.2",
     "px2agent": "^2.0.2",
     "px2dt-localdata-access": "git://github.com/tomk79/node-px2dt-localdata-access.git",
+    "rimraf": "^2.4.4",
     "rmdir": "^1.1.0",
     "socket.io": "^1.3.5",
     "twig": "^0.8.2"


### PR DESCRIPTION
・libs内broccoli-*を削除する処理を追加
・新規`npm i`する際に毎回、gulp-sassのインストール失敗するので、リビルド処理を追加
